### PR TITLE
Imply random, it's required on the client

### DIFF
--- a/package.js
+++ b/package.js
@@ -16,6 +16,7 @@ Package.on_use(function (api){
 	api.use(["meteor-base","coffeescript","mongo"], ["client", "server"]);
 	api.use(["templating"], "client");
 	api.use(["check","random"], ["client","server"]);
+	api.imply(["random"], "client");
 
 	// External Packages
 	api.use(["matb33:collection-hooks@0.7.3"], ["client", "server"],{weak:true});


### PR DESCRIPTION
Haven't actually tested this PR, but it looks good. :-)

We had an issue because the `random` package wasn't included in our app. This should fix that issue.