### PR TITLE
Added preview field in local collection

### DIFF
--- a/client/functions.coffee
+++ b/client/functions.coffee
@@ -85,6 +85,7 @@ Cloudinary =
 								loaded:event.loaded
 								total:event.total
 								percent_uploaded: Math.floor ((event.loaded / event.total) * 100)
+								preview: file
 					,false
 
 				Cloudinary.xhr.addEventListener "load", ->


### PR DESCRIPTION
Stores the dataURL string of the uploaded file in local collection. Useful to show a preview client-side while the file is being uploaded.