### PR TITLE
Option to add specific fields to local collection

### DIFF
--- a/client/functions.coffee
+++ b/client/functions.coffee
@@ -78,14 +78,20 @@ Cloudinary =
 				# Send data
 				Cloudinary.xhr = new XMLHttpRequest()
 
+				# Set fields
+				fields = _.extend ops.fields,
+					_id: collection_id
+					status: 'uploading'
+					preview: file
+
+				Cloudinary.collection.insert fields						
+
 				Cloudinary.xhr.upload.addEventListener "progress", (event) ->
-						Cloudinary.collection.upsert _id:collection_id,
+						Cloudinary.collection.update _id:collection_id,
 							$set:
-								status:"uploading"
 								loaded:event.loaded
 								total:event.total
 								percent_uploaded: Math.floor ((event.loaded / event.total) * 100)
-								preview: file
 					,false
 
 				Cloudinary.xhr.addEventListener "load", ->


### PR DESCRIPTION
Useful when having multiple file upload on the same page for example, a field can be added to differentiate photo galleries.

Usage example:

Cloudinary.upload(file, {
  fields: {
    postId: ...,
    userId: ...
  }
}, (err, res) => {});

-----

You may need to check my code because I also separated insert & update operations. Seems to work fine on my machine... But perhaps you did this for a specific reason :) Also, I'm not an expert at Coffeescript.