### PR TITLE
Fix regression from 51ae5b4: Method call only succeeds if fields obje…

### DIFF
--- a/client/functions.coffee
+++ b/client/functions.coffee
@@ -79,7 +79,7 @@ Cloudinary =
 				Cloudinary.xhr = new XMLHttpRequest()
 
 				# Set fields
-				fields = _.extend ops.fields,
+				fields = _.extend ops.fields || {},
 					_id: collection_id
 					status: 'uploading'
 					preview: file


### PR DESCRIPTION
Fix regression from 51ae5b4: Method call only succeeds if fields object is passed to `Cloudinary.upload`.

This is now possible again:
`Cloudinary.upload(files, { folder: 'SampleFolder' }, (error, uploadedFile) => { ... });`